### PR TITLE
Add flag to get KSKs from trust anchor instead of DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This tool writes out a copy of the current DNSSEC trust anchor. It is compatible with both Python 2.7 and Python 3.x, and has no dependencies except [Python](https://www.python.org/) and the [OpenSSL](https://www.openssl.org/) command line tool.
 
-The DNSSEC trust anchor will be fetch from [IANA](https://www.iana.org/dnssec), and the root KSK (Key Signing Key) will be fetched using [Google Public DNS](https://developers.google.com/speed/public-dns/) over HTTPS or by downloading the [root zone file](https://www.internic.net/domain/root.zone).
+The DNSSEC trust anchor will be fetch from [IANA](https://www.iana.org/dnssec), and the root KSK (Key Signing Key) will be fetched using [Google Public DNS](https://developers.google.com/speed/public-dns/) over HTTPS, by downloading the [root zone file](https://www.internic.net/domain/root.zone), or optionally directly from the DNSSEC trust anchor.
 
 
 ## Usage

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -172,7 +172,7 @@ def extract_ksks_from_trust_anchors(valid_trust_anchors):
     print("Extracting KSKs from trust anchor...")
     ksks = []
     for (i, anchor) in enumerate(valid_trust_anchors):
-        if not "PublicKey" in anchor or not "Flags" in anchor:
+        if "PublicKey" not in anchor or "Flags" not in anchor:
             print("Trust anchor {} does not include both PublicKey and Flags values.".format(i))
             continue
         ksks.append({'f': anchor["Flags"], 'p': 3, 'a': anchor["Algorithm"], 'k': anchor["PublicKey"]})

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -167,11 +167,11 @@ def dnskey_to_hex_of_hash(dnskey_dict, hash_type):
     return (this_hash.hexdigest()).upper()
 
 
-def extract_ksks_from_trust_anchors(trust_anchors):
+def extract_ksks_from_trust_anchors(valid_trust_anchors):
     """Extract and return the KSKs from the parsed trust anchors."""
     print("Extracting KSKs from trust anchor...")
     ksks = []
-    for (i, anchor) in enumerate(trust_anchors):
+    for (i, anchor) in enumerate(valid_trust_anchors):
         if not "PublicKey" in anchor or not "Flags" in anchor:
             print("Trust anchor {} does not include both PublicKey and Flags values.".format(i))
             continue
@@ -473,7 +473,7 @@ def main():
     ### Step 6. Verify that the trust anchors match the published KSKs
     ### file.
     if opts.ksks_from_trust_anchor:
-        ksk_records = extract_ksks_from_trust_anchors(trust_anchors)
+        ksk_records = extract_ksks_from_trust_anchors(valid_trust_anchors)
     else:
         ksk_records = fetch_ksk()
     for key in ksk_records:

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -280,11 +280,10 @@ def extract_trust_anchors_from_xml(trust_anchor_xml):
             digest_value_dict[this_subelement] = this_key_tag_text
         # Optional values
         for this_subelement in ["PublicKey", "Flags"]:
-            try:
-                this_key_tag_text = (this_digest_element.find(this_subelement)).text
-            except:
+            value = this_digest_element.find(this_subelement)
+            if value is None:
                 continue
-            digest_value_dict[this_subelement] = this_key_tag_text
+            digest_value_dict[this_subelement] = value.text
         for this_attribute in ["validFrom", "validUntil"]:
             if this_attribute in this_digest_element.keys():
                 digest_value_dict[this_attribute] = this_digest_element.attrib[this_attribute]

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -415,7 +415,7 @@ def main():
     cmd_parse = argparse.ArgumentParser(description="DNSSEC Trust Anchor Tool")
     cmd_parse.add_argument("--local", dest="local", type=str,\
         help="Name of local file to use instead of getting the trust anchor from the URL")
-    cmd_parse.add_argument("--ksks_from_trust_anchor", dest="ksks_from_trust_anchor", action='store_true',\
+    cmd_parse.add_argument("--ksks-from-trust-anchor", dest="ksks_from_trust_anchor", action='store_true',\
         help="Use the KSKs from the trust anchor instead of from DNS.")
     cmd_parse.add_argument("--keep", dest="keep", action='store_true',\
         help="Keep the temporary files (the XML and validating signature")

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -167,9 +167,9 @@ def dnskey_to_hex_of_hash(dnskey_dict, hash_type):
     return (this_hash.hexdigest()).upper()
 
 
-def extract_ksks_from_anchors(trust_anchors):
-    """Extract and return the KSKs from the parsed trust anchors data."""
-    print("Extracting KSKs from trust anchors data...")
+def extract_ksks_from_trust_anchors(trust_anchors):
+    """Extract and return the KSKs from the parsed trust anchors."""
+    print("Extracting KSKs from trust anchor...")
     ksks = []
     for (i, anchor) in enumerate(trust_anchors):
         if not "PublicKey" in anchor or not "Flags" in anchor:
@@ -415,8 +415,8 @@ def main():
     cmd_parse = argparse.ArgumentParser(description="DNSSEC Trust Anchor Tool")
     cmd_parse.add_argument("--local", dest="local", type=str,\
         help="Name of local file to use instead of getting the trust anchor from the URL")
-    cmd_parse.add_argument("--ksks_from_anchors_file", dest="ksks_from_anchors_file", action='store_true',\
-        help="Use the KSKs from the trust anchors file instead of from DNS.")
+    cmd_parse.add_argument("--ksks_from_trust_anchor", dest="ksks_from_trust_anchor", action='store_true',\
+        help="Use the KSKs from the trust anchor instead of from DNS.")
     cmd_parse.add_argument("--keep", dest="keep", action='store_true',\
         help="Keep the temporary files (the XML and validating signature")
     opts = cmd_parse.parse_args()
@@ -472,8 +472,8 @@ def main():
 
     ### Step 6. Verify that the trust anchors match the published KSKs
     ### file.
-    if opts.ksks_from_anchors_file:
-        ksk_records = extract_ksks_from_anchors(trust_anchors)
+    if opts.ksks_from_trust_anchor:
+        ksk_records = extract_ksks_from_trust_anchors(trust_anchors)
     else:
         ksk_records = fetch_ksk()
     for key in ksk_records:

--- a/get_trust_anchor.py
+++ b/get_trust_anchor.py
@@ -173,7 +173,7 @@ def extract_ksks_from_anchors(trust_anchors):
     ksks = []
     for (i, anchor) in enumerate(trust_anchors):
         if not "PublicKey" in anchor or not "Flags" in anchor:
-            print("Trust anchor {} does not include both PublicKey and Flags values.", )
+            print("Trust anchor {} does not include both PublicKey and Flags values.".format(i))
             continue
         ksks.append({'f': anchor["Flags"], 'p': 3, 'a': anchor["Algorithm"], 'k': anchor["PublicKey"]})
     return ksks


### PR DESCRIPTION
This can be used to retrieve and validate KSKs that are not yet published in the root zone but that are published in `root-anchors.xml`, such as KSK-2024.